### PR TITLE
Fixed bug for gedit 3.0.6

### DIFF
--- a/reflow.py
+++ b/reflow.py
@@ -71,7 +71,7 @@ class ReflowPlugin(GObject.Object, Gedit.WindowActivatable):
         self._action_group.set_sensitive(
             self.window.get_active_document() != None)
 
-    def _reflow(self, action=None):
+    def _reflow(self, action, data=None):
         begin, end = self._get_paragraph()
         if begin == end:
             return


### PR DESCRIPTION
Hey,.

the plugin does not work for gedit 3.0.6. On performing the reflow action, I got this error:
TypeError: _reflow() takes at most 2 arguments (3 given)
I changed _reflow() to take 3 arguments, as seen in a gedit 3 plugin tutorial.
Works for me.

Nice little plugin! Missed the functionality from emacs.
Christian
