### PR TITLE
Spews warnings about the Reflow action not existing

### DIFF
--- a/reflow.py
+++ b/reflow.py
@@ -65,6 +65,10 @@ class ReflowPlugin(GObject.Object, Gedit.WindowActivatable):
         manager = self.window.get_ui_manager()
         manager.remove_action_group(self._action_group)
         self._action_group = None
+
+        manager.remove_ui(self._menu_ui_id)
+        self._menu_ui_id = None
+
         manager.ensure_update()
 
     def do_update_state(self):


### PR DESCRIPTION
Hey, first of all thanks for the great plugin, I'm emacsifying my gedit a bit, and your plugin has played a major role in making me comfortable =)

I launch gedit from a terminal very often, and I always get warnings about the Reflow action not existing, this commit fixes it.
